### PR TITLE
fix deprecated async_forward_entry_setup call

### DIFF
--- a/custom_components/kostal/__init__.py
+++ b/custom_components/kostal/__init__.py
@@ -111,8 +111,8 @@ class KostalInstance:
         self, sensors: list[SENSOR_TYPE_KEY], piko: PikoHolder
     ) -> None:
         """Add async sensors to HASS."""
-        await self.hass.config_entries.async_forward_entry_setup(
-            self.config_entry, "sensor"
+        await self.hass.config_entries.async_forward_entry_setups(
+            self.config_entry, ["sensor"]
         )
         async_dispatcher_send(
             self.hass,


### PR DESCRIPTION
`async_forward_entry_setup()` is deprecated as of Home Assistant 2024.7, see here:
https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/